### PR TITLE
Restricting allowed version of GraphQLite with this bundle.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require" : {
     "php" : ">=7.1",
-    "thecodingmachine/graphqlite" : "^3",
+    "thecodingmachine/graphqlite" : "~3.0.0",
     "symfony/framework-bundle": "^4.1.9",
     "doctrine/annotations": "^1.6",
     "doctrine/cache": "^1.8",


### PR DESCRIPTION
The bundle is accessing to inner classes of the package whose signature may move in the future.
Let's admit that for each minor version, we will have a minor version of the module. This will be easier to maintain.