### PR TITLE
Error HTTP code when an error occurs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
   fast_finish: true
   include:
       # Test the latest stable release
-    - php: 7.1
     - php: 7.2
     - php: 7.3
       env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text"
@@ -31,7 +30,7 @@ matrix:
     # Minimum supported dependencies with the latest and oldest PHP version
     - php: 7.3
       env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak_vendors"
-    - php: 7.1
+    - php: 7.2
       env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak_vendors"
     # Dev-master is allowed to fail.
     - env: STABILITY="dev"

--- a/Controller/GraphqliteController.php
+++ b/Controller/GraphqliteController.php
@@ -12,6 +12,7 @@ use GraphQL\Executor\ExecutionResult;
 use GraphQL\Executor\Promise\Promise;
 use GraphQL\Server\StandardServer;
 use GraphQL\Upload\UploadMiddleware;
+use function in_array;
 use function json_decode;
 use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
@@ -131,6 +132,10 @@ class GraphqliteController
                 $code = 400;
             } else {
                 $code = $error->getCode();
+                if (!isset(Response::$statusTexts[$code])) {
+                    // The exception code is not a valid HTTP code. Let's ignore it
+                    continue;
+                }
             }
             $status = max($status, $code);
         }

--- a/Tests/Fixtures/Controller/MyException.php
+++ b/Tests/Fixtures/Controller/MyException.php
@@ -1,0 +1,37 @@
+<?php
+
+
+namespace TheCodingMachine\Graphqlite\Bundle\Tests\Fixtures\Controller;
+
+
+use GraphQL\Error\ClientAware;
+
+class MyException extends \Exception implements ClientAware
+{
+
+    /**
+     * Returns true when exception message is safe to be displayed to a client.
+     *
+     * @return bool
+     *
+     * @api
+     */
+    public function isClientSafe()
+    {
+        return true;
+    }
+
+    /**
+     * Returns string describing a category of the error.
+     *
+     * Value "graphql" is reserved for errors produced by query parsing or validation, do not use it.
+     *
+     * @return string
+     *
+     * @api
+     */
+    public function getCategory()
+    {
+        return 'foobar';
+    }
+}

--- a/Tests/Fixtures/Controller/TestGraphqlController.php
+++ b/Tests/Fixtures/Controller/TestGraphqlController.php
@@ -56,4 +56,13 @@ class TestGraphqlController
     {
         return new ArrayResult([new Contact('Mouf')]);
     }
+
+    /**
+     * @Query()
+     * @return string
+     */
+    public function triggerError(): string
+    {
+        throw new MyException('Boom');
+    }
 }

--- a/Tests/FunctionalTest.php
+++ b/Tests/FunctionalTest.php
@@ -58,4 +58,29 @@ class FunctionalTest extends TestCase
             ]
         ], $result);
     }
+
+    public function testErrors()
+    {
+        $kernel = new GraphqliteTestingKernel('test', true);
+        $kernel->boot();
+
+        $request = Request::create('/graphql', 'GET', ['query' => '
+        { 
+          notExists
+        }']);
+
+        $response = $kernel->handle($request);
+
+        $this->assertSame(400, $response->getStatusCode());
+
+        $request = Request::create('/graphql', 'GET', ['query' => '
+        { 
+          triggerError
+        }']);
+
+        $response = $kernel->handle($request);
+
+        $this->assertSame(500, $response->getStatusCode());
+
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   }
   ],
   "require" : {
-    "php" : ">=7.1",
+    "php" : ">=7.2",
     "thecodingmachine/graphqlite" : "~4.0.0",
     "symfony/framework-bundle": "^4.1.9",
     "doctrine/annotations": "^1.6",


### PR DESCRIPTION
This is a tricky one as GraphQL allows partial results.
So far, the HTTP error code was always 200.
Now, if there is NO response at all (no partial response, only errors), the error code >= 400.

You get HTTP 400 for malformed GraphQL queries, HTTP 500 for most exceptions unless you exception has a code (in which case you get this code).