### PR TITLE
Update GraphqliteCompilerPass.php

### DIFF
--- a/DependencyInjection/GraphqliteCompilerPass.php
+++ b/DependencyInjection/GraphqliteCompilerPass.php
@@ -162,7 +162,7 @@ class GraphqliteCompilerPass implements CompilerPassInterface
                     }
                     $customTypes[$phpClass] = new Reference($id);
                 } else {
-                    $customNotMappedTypes = new Reference($id);
+                    $customNotMappedTypes[] = new Reference($id);
                 }
             }
         }


### PR DESCRIPTION
PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Argument 1 passed to TheCodingMachine\GraphQLite\Mappers\StaticTypeMapper::setNotMappedTypes() must be of the type array, object given