### PR TITLE
Autowire services in parameters

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -35,7 +35,13 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('INCLUDE_TRACE')->defaultFalse()->info('Include stacktrace in output when an error arises')->end()
                 ->booleanNode('RETHROW_INTERNAL_EXCEPTIONS')->defaultFalse()->info('Exceptions are not caught by the engine and propagated to Symfony')->end()
                 ->booleanNode('RETHROW_UNSAFE_EXCEPTIONS')->defaultTrue()->info('Exceptions that do not implement ClientAware interface are not caught by the engine and propagated to Symfony.')->end()
+                ->end()
             ->end()
+            ->arrayNode('autowire')
+                ->children()
+                ->booleanNode('by_class_name')->defaultTrue()->info('Autowire services based on the parameter\'s fully qualified class name')->end()
+                ->booleanNode('by_parameter_name')->defaultFalse()->info('Autowire services based on the parameter\'s name')->end()
+                ->end()
             ->end()
         ;
 

--- a/DependencyInjection/GraphqliteCompilerPass.php
+++ b/DependencyInjection/GraphqliteCompilerPass.php
@@ -332,8 +332,9 @@ class GraphqliteCompilerPass implements CompilerPassInterface
      */
     private function getClassList(string $namespace, int $globTtl = 2, bool $recursive = true): array
     {
-        $explorer      = new GlobClassExplorer($namespace, $this->getPsr16Cache(), $globTtl, ClassNameMapper::createFromComposerFile(null, null, true), $recursive);
-        $allClasses       = $explorer->getClasses();
+        $explorer = new GlobClassExplorer($namespace, $this->getPsr16Cache(), $globTtl, ClassNameMapper::createFromComposerFile(null, null, true), $recursive);
+        $allClasses = $explorer->getClasses();
+        $classes = [];
         foreach ($allClasses as $className) {
             if (! class_exists($className)) {
                 continue;

--- a/DependencyInjection/GraphqliteExtension.php
+++ b/DependencyInjection/GraphqliteExtension.php
@@ -54,8 +54,22 @@ class GraphqliteExtension extends Extension
             $namespaceType = [];
         }
 
+        if (isset($configs[0]['autowire']['by_class_name'])) {
+            $autowireByClassName = $configs[0]['autowire']['by_class_name'];
+        } else {
+            $autowireByClassName = true;
+        }
+        if (isset($configs[0]['autowire']['by_parameter_name'])) {
+            $autowireByParameterName = $configs[0]['autowire']['by_parameter_name'];
+        } else {
+            $autowireByParameterName = false;
+        }
+
         $container->setParameter('graphqlite.namespace.controllers', $namespaceController);
         $container->setParameter('graphqlite.namespace.types', $namespaceType);
+
+        $container->setParameter('graphqlite.autowire.by_class_name', $autowireByClassName);
+        $container->setParameter('graphqlite.autowire.by_parameter_name', $autowireByParameterName);
 
         $loader->load('graphqlite.xml');
 

--- a/Resources/config/container/graphqlite.xml
+++ b/Resources/config/container/graphqlite.xml
@@ -29,6 +29,17 @@
 
         <service id="TheCodingMachine\GraphQLite\Mappers\Root\RootTypeMapperInterface" alias="TheCodingMachine\GraphQLite\Mappers\Root\CompositeRootTypeMapper" />
 
+        <service id="TheCodingMachine\GraphQLite\Mappers\Parameters\ResolveInfoParameterMapper">
+            <tag name="graphql.parameter_mapper" />
+        </service>
+
+        <service id="TheCodingMachine\GraphQLite\Mappers\Parameters\ContainerParameterMapper">
+            <argument type="service" id="service_container" />
+            <argument>%graphqlite.autowire.by_class_name%</argument>
+            <argument>%graphqlite.autowire.by_parameter_name%</argument>
+            <tag name="graphql.parameter_mapper" />
+        </service>
+
         <service id="TheCodingMachine\GraphQLite\Mappers\Parameters\CompositeParameterMapper">
             <argument type="tagged" tag="graphql.parameter_mapper" />
         </service>

--- a/Tests/Fixtures/Entities/Contact.php
+++ b/Tests/Fixtures/Entities/Contact.php
@@ -6,8 +6,10 @@ namespace TheCodingMachine\Graphqlite\Bundle\Tests\Fixtures\Entities;
 
 use DateTimeInterface;
 use Psr\Http\Message\UploadedFileInterface;
+use stdClass;
 use TheCodingMachine\GraphQLite\Annotations\Field;
 use TheCodingMachine\GraphQLite\Annotations\Type;
+use TheCodingMachine\Graphqlite\Bundle\Tests\Fixtures\Controller\TestGraphqlController;
 
 /**
  * @Type()
@@ -30,5 +32,17 @@ class Contact
     public function getName(): string
     {
         return $this->name;
+    }
+
+    /**
+     * @Field()
+     * @return string
+     */
+    public function injectService(TestGraphqlController $testService = null): string
+    {
+        if (!$testService instanceof TestGraphqlController) {
+            return 'KO';
+        }
+        return 'OK';
     }
 }

--- a/Tests/Fixtures/Entities/Contact.php
+++ b/Tests/Fixtures/Entities/Contact.php
@@ -38,9 +38,9 @@ class Contact
      * @Field()
      * @return string
      */
-    public function injectService(TestGraphqlController $testService = null): string
+    public function injectService(TestGraphqlController $testService = null, stdClass $someService = null): string
     {
-        if (!$testService instanceof TestGraphqlController) {
+        if (!$testService instanceof TestGraphqlController || $someService === null) {
             return 'KO';
         }
         return 'OK';

--- a/Tests/Fixtures/config/services.yaml
+++ b/Tests/Fixtures/config/services.yaml
@@ -17,6 +17,8 @@ services:
         resource: '../*'
         exclude: '../{Entities}'
 
+    someService:
+        class: stdClass
     # controllers are imported separately to make sure services can be injected
     # as action arguments even if you don't extend any base controller class
     #App\Controller\:

--- a/Tests/FunctionalTest.php
+++ b/Tests/FunctionalTest.php
@@ -2,6 +2,7 @@
 
 namespace TheCodingMachine\Graphqlite\Bundle\Tests;
 
+use function json_decode;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use TheCodingMachine\GraphQLite\Schema;
@@ -54,6 +55,36 @@ class FunctionalTest extends TestCase
                 ],
                 'contacts' => [
                     'count' => 1
+                ]
+            ]
+        ], $result);
+    }
+
+    public function testServiceAutowiring()
+    {
+        $kernel = new GraphqliteTestingKernel('test', true);
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        $schema = $container->get(Schema::class);
+        $this->assertInstanceOf(Schema::class, $schema);
+        $schema->assertValid();
+
+        $request = Request::create('/graphql', 'GET', ['query' => '
+        { 
+          contact {
+            injectService
+          } 
+        }']);
+
+        $response = $kernel->handle($request);
+
+        $result = json_decode($response->getContent(), true);
+
+        $this->assertSame([
+            'data' => [
+                'contact' => [
+                    'injectService' => 'OK',
                 ]
             ]
         ], $result);

--- a/Tests/GraphqliteTestingKernel.php
+++ b/Tests/GraphqliteTestingKernel.php
@@ -40,6 +40,9 @@ class GraphqliteTestingKernel extends Kernel
                 'namespace' => [
                     'controllers' => ['TheCodingMachine\\Graphqlite\\Bundle\\Tests\\Fixtures\\Controller\\'],
                     'types' => ['TheCodingMachine\\Graphqlite\\Bundle\\Tests\\Fixtures\\Types\\', 'TheCodingMachine\\Graphqlite\\Bundle\\Tests\\Fixtures\\Entities\\']
+                ],
+                'autowire' => [
+                    'by_parameter_name' => true
                 ]
             ));
         });

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,15 @@
   ],
   "require" : {
     "php" : ">=7.2",
-    "thecodingmachine/graphqlite" : "~4.0.0",
+    "thecodingmachine/graphqlite" : "dev-autowiring as 4.0.0",
     "symfony/framework-bundle": "^4.1.9",
     "doctrine/annotations": "^1.6",
     "doctrine/cache": "^1.8",
     "symfony/psr-http-message-bridge": "^1",
     "nyholm/psr7": "^1.1",
     "zendframework/zend-diactoros": "^1.8.6",
-    "overblog/graphiql-bundle": "^0.1.2"
+    "overblog/graphiql-bundle": "^0.1.2",
+    "thecodingmachine/cache-utils": "^1"
   },
   "require-dev": {
     "symfony/security-bundle": "^4.1.9",
@@ -33,6 +34,12 @@
     "phpstan/phpstan": "^0.10.6",
     "beberlei/porpaginas": "^1.2"
   },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/moufmouf/graphqlite"
+    }
+  ],
   "scripts": {
     "phpstan": "phpstan analyse GraphqliteBundle.php DependencyInjection/ Controller/ Resources/ Security/ -c phpstan.neon --level=7 --no-progress"
   },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require" : {
     "php" : ">=7.2",
-    "thecodingmachine/graphqlite" : "dev-autowiring as 4.0.0",
+    "thecodingmachine/graphqlite" : "^4",
     "symfony/framework-bundle": "^4.1.9",
     "doctrine/annotations": "^1.6",
     "doctrine/cache": "^1.8",
@@ -34,12 +34,6 @@
     "phpstan/phpstan": "^0.10.6",
     "beberlei/porpaginas": "^1.2"
   },
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/moufmouf/graphqlite"
-    }
-  ],
   "scripts": {
     "phpstan": "phpstan analyse GraphqliteBundle.php DependencyInjection/ Controller/ Resources/ Security/ -c phpstan.neon --level=7 --no-progress"
   },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,8 @@
         <whitelist>
             <directory>./</directory>
             <exclude>
+                <directory>cache</directory>
+                <directory>build</directory>
                 <directory>./Resources</directory>
                 <directory>./Tests</directory>
                 <directory>./vendor</directory>


### PR DESCRIPTION
This PR adds the ability to autowire services in parameters.
The hard part with Symfony is to detect all services that must be marked public (i.e. all services that could be used by GraphQLite to inject a service).