### PR TITLE
FieldMiddlewarePipe injection is broken

### DIFF
--- a/Tests/Fixtures/Controller/TestGraphqlController.php
+++ b/Tests/Fixtures/Controller/TestGraphqlController.php
@@ -6,6 +6,8 @@ namespace TheCodingMachine\Graphqlite\Bundle\Tests\Fixtures\Controller;
 
 use GraphQL\Error\Error;
 use Porpaginas\Arrays\ArrayResult;
+use TheCodingMachine\GraphQLite\Annotations\FailWith;
+use TheCodingMachine\GraphQLite\Annotations\Logged;
 use TheCodingMachine\Graphqlite\Bundle\Tests\Fixtures\Entities\Contact;
 use TheCodingMachine\Graphqlite\Bundle\Tests\Fixtures\Entities\Product;
 use TheCodingMachine\GraphQLite\Annotations\Mutation;
@@ -65,5 +67,16 @@ class TestGraphqlController
     public function triggerException(int $code = 0): string
     {
         throw new MyException('Boom', $code);
+    }
+
+    /**
+     * @Query()
+     * @Logged()
+     * @FailWith(null)
+     * @return string
+     */
+    public function loggedQuery(): string
+    {
+        return 'foo';
     }
 }

--- a/Tests/FunctionalTest.php
+++ b/Tests/FunctionalTest.php
@@ -125,4 +125,25 @@ class FunctionalTest extends TestCase
 
         $this->assertSame(404, $response->getStatusCode(), $response->getContent());
     }
+
+    public function testLoggedMiddleware()
+    {
+        $kernel = new GraphqliteTestingKernel('test', true);
+        $kernel->boot();
+
+        $request = Request::create('/graphql', 'GET', ['query' => '
+        { 
+          loggedQuery
+        }']);
+
+        $response = $kernel->handle($request);
+
+        $result = json_decode($response->getContent(), true);
+
+        $this->assertSame([
+            'data' => [
+                'loggedQuery' => null
+            ]
+        ], $result);
+    }
 }


### PR DESCRIPTION
No services are injected in @FieldMiddlewarePipe. As a result, the @Logged and @Right annotations are broken.

We might gain some stability by migrating to SchemaFactory usage in the bundle.

This PR starts with a failing test.

Closes #18