### PR TITLE
Adding the ability to type-hint on a Symfony request

### DIFF
--- a/Context/SymfonyGraphQLContext.php
+++ b/Context/SymfonyGraphQLContext.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace TheCodingMachine\Graphqlite\Bundle\Context;
+
+
+use Symfony\Component\HttpFoundation\Request;
+
+class SymfonyGraphQLContext implements SymfonyRequestContextInterface
+{
+    /**
+     * @var Request
+     */
+    private $request;
+
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * @return Request
+     */
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+}

--- a/Context/SymfonyRequestContextInterface.php
+++ b/Context/SymfonyRequestContextInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace TheCodingMachine\Graphqlite\Bundle\Context;
+
+use Symfony\Component\HttpFoundation\Request;
+
+interface SymfonyRequestContextInterface
+{
+    /**
+     * @return Request
+     */
+    public function getRequest(): Request;
+}

--- a/Controller/GraphQL/InvalidUserPasswordException.php
+++ b/Controller/GraphQL/InvalidUserPasswordException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace TheCodingMachine\Graphqlite\Bundle\Controller\GraphQL;
+
+
+class InvalidUserPasswordException
+{
+
+}

--- a/Controller/GraphQL/LoginController.php
+++ b/Controller/GraphQL/LoginController.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace TheCodingMachine\Graphqlite\Bundle\Controller\GraphQL;
+
+
+class LoginController
+{
+
+}

--- a/Mappers/RequestParameter.php
+++ b/Mappers/RequestParameter.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace TheCodingMachine\Graphqlite\Bundle\Mappers;
+
+
+use GraphQL\Type\Definition\ResolveInfo;
+use TheCodingMachine\Graphqlite\Bundle\Context\SymfonyRequestContextInterface;
+use TheCodingMachine\GraphQLite\GraphQLException;
+use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
+
+class RequestParameter implements ParameterInterface
+{
+
+    /**
+     * @param array<string, mixed> $args
+     * @param mixed $context
+     *
+     * @return mixed
+     */
+    public function resolve(?object $source, array $args, $context, ResolveInfo $info)
+    {
+        if (!$context instanceof SymfonyRequestContextInterface) {
+            throw new GraphQLException('Cannot type-hint on a Symfony Request object in your query/mutation/field. The request context must implement SymfonyRequestContextInterface.');
+        }
+        return $context->getRequest();
+    }
+}

--- a/Mappers/RequestParameterMapper.php
+++ b/Mappers/RequestParameterMapper.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace TheCodingMachine\Graphqlite\Bundle\Mappers;
+
+
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\Type;
+use ReflectionParameter;
+use Symfony\Component\HttpFoundation\Request;
+use TheCodingMachine\GraphQLite\Annotations\ParameterAnnotations;
+use TheCodingMachine\GraphQLite\Mappers\Parameters\ParameterMapperInterface;
+use TheCodingMachine\GraphQLite\Parameters\ParameterInterface;
+
+class RequestParameterMapper implements ParameterMapperInterface
+{
+
+    public function mapParameter(ReflectionParameter $parameter, DocBlock $docBlock, ?Type $paramTagType, ParameterAnnotations $parameterAnnotations): ?ParameterInterface
+    {
+        if ($parameter->getType()->getName() === Request::class) {
+            return new RequestParameter();
+        }
+        return null;
+    }
+}

--- a/Resources/config/container/graphqlite.xml
+++ b/Resources/config/container/graphqlite.xml
@@ -47,10 +47,6 @@
 
         <service id="TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface" alias="TheCodingMachine\Graphqlite\Bundle\Security\AuthorizationService" />
 
-        <service id="GraphQL\Server\StandardServer">
-            <argument type="service" id="GraphQL\Server\ServerConfig" />
-        </service>
-
         <service id="GraphQL\Server\ServerConfig">
             <call method="setSchema">
                 <argument type="service" id="TheCodingMachine\GraphQLite\Schema"/>
@@ -62,6 +58,10 @@
         </service>
 
         <service id="TheCodingMachine\Graphqlite\Bundle\Controller\GraphqliteController" public="true" />
+
+        <service id="TheCodingMachine\Graphqlite\Bundle\Mappers\RequestParameterMapper">
+            <tag name="graphql.parameter_mapper"/>
+        </service>
     </services>
 
 </container>

--- a/Tests/Fixtures/Controller/TestGraphqlController.php
+++ b/Tests/Fixtures/Controller/TestGraphqlController.php
@@ -6,6 +6,7 @@ namespace TheCodingMachine\Graphqlite\Bundle\Tests\Fixtures\Controller;
 
 use GraphQL\Error\Error;
 use Porpaginas\Arrays\ArrayResult;
+use Symfony\Component\HttpFoundation\Request;
 use TheCodingMachine\GraphQLite\Annotations\FailWith;
 use TheCodingMachine\GraphQLite\Annotations\Logged;
 use TheCodingMachine\GraphQLite\Annotations\Right;
@@ -101,5 +102,14 @@ class TestGraphqlController
     public function withUserRight(): string
     {
         return 'foo';
+    }
+
+    /**
+     * @Query()
+     * @return string
+     */
+    public function getUri(Request $request): string
+    {
+        return $request->getPathInfo();
     }
 }

--- a/Tests/FunctionalTest.php
+++ b/Tests/FunctionalTest.php
@@ -17,7 +17,7 @@ use function var_dump;
 
 class FunctionalTest extends TestCase
 {
-    public function testServiceWiring()
+    public function testServiceWiring(): void
     {
         $kernel = new GraphqliteTestingKernel('test', true);
         $kernel->boot();
@@ -68,7 +68,7 @@ class FunctionalTest extends TestCase
         ], $result);
     }
 
-    public function testServiceAutowiring()
+    public function testServiceAutowiring(): void
     {
         $kernel = new GraphqliteTestingKernel('test', true);
         $kernel->boot();
@@ -98,7 +98,7 @@ class FunctionalTest extends TestCase
         ], $result);
     }
 
-    public function testErrors()
+    public function testErrors(): void
     {
         $kernel = new GraphqliteTestingKernel('test', true);
         $kernel->boot();
@@ -134,7 +134,7 @@ class FunctionalTest extends TestCase
         $this->assertSame(404, $response->getStatusCode(), $response->getContent());
     }
 
-    public function testLoggedMiddleware()
+    public function testLoggedMiddleware(): void
     {
         $kernel = new GraphqliteTestingKernel('test', true);
         $kernel->boot();
@@ -155,7 +155,7 @@ class FunctionalTest extends TestCase
         ], $result);
     }
 
-    public function testLoggedMiddleware2()
+    public function testLoggedMiddleware2(): void
     {
         $kernel = new GraphqliteTestingKernel('test', true);
         $kernel->boot();
@@ -183,6 +183,27 @@ class FunctionalTest extends TestCase
             ]
         ], $result);
 
+    }
+
+    public function testInjectQuery(): void
+    {
+        $kernel = new GraphqliteTestingKernel('test', true);
+        $kernel->boot();
+
+        $request = Request::create('/graphql', 'GET', ['query' => '
+        { 
+          uri
+        }']);
+
+        $response = $kernel->handle($request);
+
+        $result = json_decode($response->getContent(), true);
+
+        $this->assertSame([
+            'data' => [
+                'uri' => '/graphql'
+            ]
+        ], $result);
     }
 
     private function logIn(ContainerInterface $container)


### PR DESCRIPTION
You can now type-hint a parameter to a Symfony request object.
Useful to get the session for instance.