### PR TITLE
Add a "me" query and modify login return type

### DIFF
--- a/Controller/GraphQL/LoginController.php
+++ b/Controller/GraphQL/LoginController.php
@@ -9,6 +9,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use TheCodingMachine\GraphQLite\Annotations\Mutation;
@@ -55,12 +56,12 @@ class LoginController
     /**
      * @Mutation()
      */
-    public function login(string $userName, string $password, Request $request): bool
+    public function login(string $userName, string $password, Request $request): UserInterface
     {
         try {
             $user = $this->userProvider->loadUserByUsername($userName);
         } catch (UsernameNotFoundException $e) {
-            // FIXME: should we return false instead???
+            // FIXME: should we return null instead???
             throw InvalidUserPasswordException::create($e);
         }
 
@@ -83,7 +84,7 @@ class LoginController
         $event = new InteractiveLoginEvent($request, $token);
         $this->eventDispatcher->dispatch($event, 'security.interactive_login');
 
-        return true;
+        return $user;
     }
 
     /**

--- a/Controller/GraphQL/MeController.php
+++ b/Controller/GraphQL/MeController.php
@@ -1,0 +1,51 @@
+<?php
+namespace TheCodingMachine\Graphqlite\Bundle\Controller\GraphQL;
+
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use TheCodingMachine\GraphQLite\Annotations\Mutation;
+use TheCodingMachine\GraphQLite\Annotations\Query;
+use TheCodingMachine\Graphqlite\Bundle\Types\BasicUser;
+
+class MeController
+{
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    public function __construct(TokenStorageInterface $tokenStorage)
+    {
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    /**
+     * @Query()
+     */
+    public function me(): ?UserInterface
+    {
+        $token = $this->tokenStorage->getToken();
+        if ($token === null) {
+            return null;
+        }
+
+        $user = $this->tokenStorage->getToken()->getUser();
+
+        if (!$user instanceof UserInterface) {
+            // getUser() can be an object with a toString or a string
+            $userName = (string) $user;
+            $user = new BasicUser($userName);
+        }
+
+        return $user;
+    }
+}

--- a/Controller/GraphQL/MeController.php
+++ b/Controller/GraphQL/MeController.php
@@ -38,7 +38,7 @@ class MeController
             return null;
         }
 
-        $user = $this->tokenStorage->getToken()->getUser();
+        $user = $token->getUser();
 
         if (!$user instanceof UserInterface) {
             // getUser() can be an object with a toString or a string

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,6 +40,7 @@ class Configuration implements ConfigurationInterface
             ->arrayNode('security')
                 ->children()
                 ->enumNode('enable_login')->values(['on', 'off', 'auto'])->defaultValue('auto')->info('Enable to automatically create a login/logout mutation. "on": enable, "auto": enable if security bundle is available.')->end()
+                ->enumNode('enable_me')->values(['on', 'off', 'auto'])->defaultValue('auto')->info('Enable to automatically create a "me" query to fetch the current user. "on": enable, "auto": enable if security bundle is available.')->end()
                 ->scalarNode('firewall_name')->defaultValue('main')->info('The name of the firewall to use for login')->end()
                 ->end()
             ->end()

--- a/DependencyInjection/GraphqliteExtension.php
+++ b/DependencyInjection/GraphqliteExtension.php
@@ -55,10 +55,12 @@ class GraphqliteExtension extends Extension
         }
 
         $enableLogin = $configs[0]['security']['enable_login'] ?? 'auto';
+        $enableMe = $configs[0]['security']['enable_me'] ?? 'auto';
 
         $container->setParameter('graphqlite.namespace.controllers', $namespaceController);
         $container->setParameter('graphqlite.namespace.types', $namespaceType);
         $container->setParameter('graphqlite.security.enable_login', $enableLogin);
+        $container->setParameter('graphqlite.security.enable_me', $enableMe);
         $container->setParameter('graphqlite.security.firewall_name', $configs[0]['security']['firewall_name'] ?? 'main');
 
         $loader->load('graphqlite.xml');

--- a/Resources/config/container/graphqlite.xml
+++ b/Resources/config/container/graphqlite.xml
@@ -20,6 +20,11 @@
             <call method="setAuthorizationService">
                 <argument type="service" id="TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface" />
             </call>
+            <!-- Ideally, we would not need to go through the GlobTypeMapper for types in packages. We shoul
+             have the opportunity to add types / models through another class (like the AggregateControllerQueryProviderFactory for queries) -->
+            <call method="addTypeNamespace">
+                <argument type="string">TheCodingMachine\Graphqlite\Bundle\Types</argument>
+            </call>
         </service>
 
         <service id="TheCodingMachine\GraphQLite\Schema" public="true">
@@ -30,7 +35,6 @@
 
         <service id="TheCodingMachine\GraphQLite\AggregateControllerQueryProviderFactory">
             <argument type="collection">
-                <argument>TheCodingMachine\Graphqlite\Bundle\Controller\GraphQL\LoginController</argument>
             </argument>
             <tag name="graphql.queryprovider_factory" />
         </service>
@@ -77,5 +81,9 @@
         <service id="TheCodingMachine\Graphqlite\Bundle\Controller\GraphQL\LoginController" public="true">
             <argument key="$firewallName">%graphqlite.security.firewall_name%</argument>
         </service>
+
+        <service id="TheCodingMachine\Graphqlite\Bundle\Controller\GraphQL\MeController" public="true" />
+
+        <service id="TheCodingMachine\Graphqlite\Bundle\Types\UserType" public="true"/>
     </services>
 </container>

--- a/Resources/config/container/graphqlite.xml
+++ b/Resources/config/container/graphqlite.xml
@@ -20,11 +20,6 @@
             <call method="setAuthorizationService">
                 <argument type="service" id="TheCodingMachine\GraphQLite\Security\AuthorizationServiceInterface" />
             </call>
-            <!-- Ideally, we would not need to go through the GlobTypeMapper for types in packages. We shoul
-             have the opportunity to add types / models through another class (like the AggregateControllerQueryProviderFactory for queries) -->
-            <call method="addTypeNamespace">
-                <argument type="string">TheCodingMachine\Graphqlite\Bundle\Types</argument>
-            </call>
         </service>
 
         <service id="TheCodingMachine\GraphQLite\Schema" public="true">
@@ -85,5 +80,12 @@
         <service id="TheCodingMachine\Graphqlite\Bundle\Controller\GraphQL\MeController" public="true" />
 
         <service id="TheCodingMachine\Graphqlite\Bundle\Types\UserType" public="true"/>
+
+        <service id="TheCodingMachine\GraphQLite\Mappers\StaticClassListTypeMapperFactory">
+            <argument type="collection">
+                <argument>TheCodingMachine\Graphqlite\Bundle\Types\UserType</argument>
+            </argument>
+            <tag name="graphql.type_mapper_factory"/>
+        </service>
     </services>
 </container>

--- a/Tests/FunctionalTest.php
+++ b/Tests/FunctionalTest.php
@@ -236,6 +236,16 @@ class FunctionalTest extends TestCase
                 ]
             ]
         ], $result);
+    }
+
+    public function testMeQuery(): void
+    {
+        $kernel = new GraphqliteTestingKernel();
+        $kernel->boot();
+
+        $session = new Session(new MockArraySessionStorage());
+        $container = $kernel->getContainer();
+        $container->set('session', $session);
 
         $request = Request::create('/graphql', 'POST', ['query' => '
         {
@@ -253,7 +263,7 @@ class FunctionalTest extends TestCase
         $this->assertSame([
             'data' => [
                 'me' => [
-                    'userName' => 'foo',
+                    'userName' => 'anon.',
                     'roles' => [],
                 ]
             ]

--- a/Tests/FunctionalTest.php
+++ b/Tests/FunctionalTest.php
@@ -222,6 +222,7 @@ class FunctionalTest extends TestCase
         mutation login { 
           login(userName: "foo", password: "bar") {
             userName
+            roles
           }
         }']);
 
@@ -232,7 +233,10 @@ class FunctionalTest extends TestCase
         $this->assertSame([
             'data' => [
                 'login' => [
-                    'userName' => 'foo'
+                    'userName' => 'foo',
+                    'roles' => [
+                        'ROLE_USER'
+                    ]
                 ]
             ]
         ], $result);
@@ -298,12 +302,77 @@ class FunctionalTest extends TestCase
         $kernel->boot();
     }
 
+    public function testForceMeNoSecurity(): void
+    {
+        $kernel = new GraphqliteTestingKernel(false, 'off', false, 'on');
+        $this->expectException(GraphQLException::class);
+        $this->expectExceptionMessage('In order to enable the "me" query (via the graphqlite.security.enable_me parameter), you need to install the security bundle.');
+        $kernel->boot();
+    }
+
     public function testForceLoginNoSecurity(): void
     {
         $kernel = new GraphqliteTestingKernel(true, 'on', false);
         $this->expectException(GraphQLException::class);
         $this->expectExceptionMessage('In order to enable the login/logout mutations (via the graphqlite.security.enable_login parameter), you need to install the security bundle. Please be sure to correctly configure the user provider (in the security.providers configuration settings)');
         $kernel->boot();
+    }
+
+    /*public function testAutoMeNoSecurity(): void
+    {
+        $kernel = new GraphqliteTestingKernel(true, null, false);
+        $kernel->boot();
+
+        $session = new Session(new MockArraySessionStorage());
+        $container = $kernel->getContainer();
+        $container->set('session', $session);
+
+        $request = Request::create('/graphql', 'POST', ['query' => '
+        {
+          me {
+            userName
+            roles
+          }
+        }
+        ']);
+
+        $response = $kernel->handle($request);
+
+        $result = json_decode($response->getContent(), true);
+
+        $this->assertSame([
+            'data' => [
+                'me' => [
+                    'userName' => 'anon.',
+                    'roles' => [],
+                ]
+            ]
+        ], $result);
+    }*/
+
+    public function testAllOff(): void
+    {
+        $kernel = new GraphqliteTestingKernel(true, 'off', true, 'off');
+        $kernel->boot();
+
+        $session = new Session(new MockArraySessionStorage());
+        $container = $kernel->getContainer();
+        $container->set('session', $session);
+
+        $request = Request::create('/graphql', 'POST', ['query' => '
+        {
+          me {
+            userName
+            roles
+          }
+        }
+        ']);
+
+        $response = $kernel->handle($request);
+
+        $result = json_decode($response->getContent(), true);
+
+        $this->assertSame('Cannot query field "me" on type "Query".', $result['errors'][0]['message']);
     }
 
     private function logIn(ContainerInterface $container)

--- a/Tests/FunctionalTest.php
+++ b/Tests/FunctionalTest.php
@@ -220,7 +220,9 @@ class FunctionalTest extends TestCase
 
         $request = Request::create('/graphql', 'POST', ['query' => '
         mutation login { 
-          login(userName: "foo", password: "bar")
+          login(userName: "foo", password: "bar") {
+            userName
+          }
         }']);
 
         $response = $kernel->handle($request);
@@ -229,9 +231,34 @@ class FunctionalTest extends TestCase
 
         $this->assertSame([
             'data' => [
-                'login' => true
+                'login' => [
+                    'userName' => 'foo'
+                ]
             ]
         ], $result);
+
+        $request = Request::create('/graphql', 'POST', ['query' => '
+        {
+          me {
+            userName
+            roles
+          }
+        }
+        ']);
+
+        $response = $kernel->handle($request);
+
+        $result = json_decode($response->getContent(), true);
+
+        $this->assertSame([
+            'data' => [
+                'me' => [
+                    'userName' => 'foo',
+                    'roles' => [],
+                ]
+            ]
+        ], $result);
+
     }
 
     public function testNoLoginNoSessionQuery(): void
@@ -241,7 +268,9 @@ class FunctionalTest extends TestCase
 
         $request = Request::create('/graphql', 'POST', ['query' => '
         mutation login { 
-          login(userName: "foo", password: "bar")
+          login(userName: "foo", password: "bar") {
+            userName
+          }
         }']);
 
         $response = $kernel->handle($request);

--- a/Tests/GraphqliteTestingKernel.php
+++ b/Tests/GraphqliteTestingKernel.php
@@ -33,13 +33,18 @@ class GraphqliteTestingKernel extends Kernel
      * @var bool
      */
     private $enableSecurity;
+    /**
+     * @var string|null
+     */
+    private $enableMe;
 
-    public function __construct(bool $enableSession = true, ?string $enableLogin = null, bool $enableSecurity = true)
+    public function __construct(bool $enableSession = true, ?string $enableLogin = null, bool $enableSecurity = true, ?string $enableMe = null)
     {
         parent::__construct('test', true);
         $this->enableSession = $enableSession;
         $this->enableLogin = $enableLogin;
         $this->enableSecurity = $enableSecurity;
+        $this->enableMe = $enableMe;
     }
 
     public function registerBundles()
@@ -112,6 +117,12 @@ class GraphqliteTestingKernel extends Kernel
             if ($this->enableLogin) {
                 $graphqliteConf['security'] = [
                     'enable_login' => $this->enableLogin,
+                ];
+            }
+
+            if ($this->enableMe) {
+                $graphqliteConf['security'] = [
+                    'enable_me' => $this->enableMe,
                 ];
             }
 

--- a/Tests/Types/BasicUserTest.php
+++ b/Tests/Types/BasicUserTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace TheCodingMachine\Graphqlite\Bundle\Types;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class BasicUserTest extends TestCase
+{
+
+    public function testGetPassword()
+    {
+        $user = new BasicUser('foo');
+
+        $this->expectException(RuntimeException::class);
+        $user->getPassword();
+    }
+
+    public function testEraseCredentials()
+    {
+        $user = new BasicUser('foo');
+
+        $this->expectException(RuntimeException::class);
+        $user->eraseCredentials();
+    }
+
+    public function testGetSalt()
+    {
+        $user = new BasicUser('foo');
+
+        $this->expectException(RuntimeException::class);
+        $user->getSalt();
+    }
+}

--- a/Types/BasicUser.php
+++ b/Types/BasicUser.php
@@ -1,0 +1,87 @@
+<?php
+
+
+namespace TheCodingMachine\Graphqlite\Bundle\Types;
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\SourceField;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class BasicUser implements UserInterface
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Returns the roles granted to the user.
+     *
+     *     public function getRoles()
+     *     {
+     *         return ['ROLE_USER'];
+     *     }
+     *
+     * Alternatively, the roles might be stored on a ``roles`` property,
+     * and populated in any number of different ways when the user object
+     * is created.
+     *
+     * @return (Role|string)[] The user roles
+     */
+    public function getRoles()
+    {
+        return [];
+    }
+
+    /**
+     * Returns the password used to authenticate the user.
+     *
+     * This should be the encoded password. On authentication, a plain-text
+     * password will be salted, encoded, and then compared to this value.
+     *
+     * @return string The password
+     */
+    public function getPassword()
+    {
+        throw new \RuntimeException('getPassword is not implemented by BasicUser');
+    }
+
+    /**
+     * Returns the salt that was originally used to encode the password.
+     *
+     * This can return null if the password was not encoded using a salt.
+     *
+     * @return string|null The salt
+     */
+    public function getSalt()
+    {
+        throw new \RuntimeException('getSalt is not implemented by BasicUser');
+    }
+
+    /**
+     * Returns the username used to authenticate the user.
+     *
+     * @return string The username
+     */
+    public function getUsername()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Removes sensitive data from the user.
+     *
+     * This is important if, at any given point, sensitive information like
+     * the plain-text password is stored on this object.
+     */
+    public function eraseCredentials()
+    {
+        throw new \RuntimeException('eraseCredentials is not implemented by BasicUser');
+    }
+}

--- a/Types/UserType.php
+++ b/Types/UserType.php
@@ -1,0 +1,29 @@
+<?php
+
+
+namespace TheCodingMachine\Graphqlite\Bundle\Types;
+
+use TheCodingMachine\GraphQLite\Annotations\Field;
+use TheCodingMachine\GraphQLite\Annotations\SourceField;
+use TheCodingMachine\GraphQLite\Annotations\Type;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * @Type(class=UserInterface::class)
+ * @SourceField(name="userName")
+ */
+class UserType
+{
+    /**
+     * @Field()
+     * @return string[]
+     */
+    public function getRoles(UserInterface $user): array
+    {
+        $roles = [];
+        foreach ($user->getRoles() as $role) {
+            $roles[] = (string) $role;
+        }
+        return $roles;
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,5 +4,6 @@ parameters:
         # Error triggered by a bad PHPDoc in Symfony
         - '#Parameter \#4 $roles of class Symfony\\Component\\Security\\Core\\Authentication\\Token\\UsernamePasswordToken constructor expects array<string>, array<string|Symfony\\Component\\Security\\Core\\Role\\Role> given.#'
         - '#Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) invoked with 2 parameters, 1 required.#'
+        - '#Cannot cast object|string to string.#'
 #includes:
 #    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon


### PR DESCRIPTION
Now that the "@Type" annotation is supported in the interfaces, we can create a "me" query and modify the return type of the "login" query to return a `UserInterface`!