### PR TITLE
UserType: too generic

### DIFF
--- a/Resources/config/container/graphqlite.xml
+++ b/Resources/config/container/graphqlite.xml
@@ -79,11 +79,11 @@
 
         <service id="TheCodingMachine\Graphqlite\Bundle\Controller\GraphQL\MeController" public="true" />
 
-        <service id="TheCodingMachine\Graphqlite\Bundle\Types\UserType" public="true"/>
+        <service id="TheCodingMachine\Graphqlite\Bundle\Types\SymfonyUserInterfaceType" public="true"/>
 
         <service id="TheCodingMachine\GraphQLite\Mappers\StaticClassListTypeMapperFactory">
             <argument type="collection">
-                <argument>TheCodingMachine\Graphqlite\Bundle\Types\UserType</argument>
+                <argument>TheCodingMachine\Graphqlite\Bundle\Types\SymfonyUserInterfaceType</argument>
             </argument>
             <tag name="graphql.type_mapper_factory"/>
         </service>

--- a/Types/SymfonyUserInterfaceType.php
+++ b/Types/SymfonyUserInterfaceType.php
@@ -12,7 +12,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * @Type(class=UserInterface::class)
  * @SourceField(name="userName")
  */
-class UserType
+class SymfonyUserInterfaceType
 {
     /**
      * @Field()


### PR DESCRIPTION
As one may create its own `UserType`, this PR rename the class `UserType` to the less generic name `SymfonyUserInterfaceType`.