### PR TITLE
Adding support for symfony validator bridge

### DIFF
--- a/Resources/config/container/graphqlite.xml
+++ b/Resources/config/container/graphqlite.xml
@@ -81,6 +81,11 @@
             <tag name="graphql.parameter_middleware"/>
         </service>
 
+        <service id="TheCodingMachine\Graphqlite\Validator\Mappers\Parameters\AssertParameterMiddleware">
+            <argument type="service" id="validator.validator_factory" />
+            <tag name="graphql.parameter_middleware"/>
+        </service>
+
         <service id="TheCodingMachine\Graphqlite\Bundle\Controller\GraphQL\LoginController" public="true">
             <argument key="$firewallName">%graphqlite.security.firewall_name%</argument>
         </service>

--- a/Tests/Fixtures/Controller/TestGraphqlController.php
+++ b/Tests/Fixtures/Controller/TestGraphqlController.php
@@ -7,6 +7,7 @@ namespace TheCodingMachine\Graphqlite\Bundle\Tests\Fixtures\Controller;
 use GraphQL\Error\Error;
 use Porpaginas\Arrays\ArrayResult;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\Constraints as Assertion;
 use TheCodingMachine\GraphQLite\Annotations\FailWith;
 use TheCodingMachine\GraphQLite\Annotations\Logged;
 use TheCodingMachine\GraphQLite\Annotations\Right;
@@ -16,6 +17,8 @@ use TheCodingMachine\GraphQLite\Annotations\Mutation;
 use TheCodingMachine\GraphQLite\Annotations\Query;
 use TheCodingMachine\GraphQLite\Exceptions\GraphQLAggregateException;
 use TheCodingMachine\GraphQLite\Exceptions\GraphQLException;
+use TheCodingMachine\Graphqlite\Validator\Annotations\Assert;
+use TheCodingMachine\Graphqlite\Validator\Fixtures\Types\User;
 
 class TestGraphqlController
 {
@@ -124,5 +127,14 @@ class TestGraphqlController
     public function getUri(Request $request): string
     {
         return $request->getPathInfo();
+    }
+
+    /**
+     * @Query
+     * @Assert(for="email", constraint=@Assertion\Email())
+     */
+    public function findByMail(string $email = 'a@a.com'): string
+    {
+        return $email;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,11 @@
   ],
   "require" : {
     "php" : ">=7.2",
-    "thecodingmachine/graphqlite" : "^4",
+    "thecodingmachine/graphqlite" : "~4.0.0",
+    "thecodingmachine/graphqlite-symfony-validator-bridge" : "~4.0.0",
     "symfony/framework-bundle": "^4.1.9",
+    "symfony/validator": "^4.1.9",
+    "symfony/translation": "^4.1.9",
     "doctrine/annotations": "^1.6",
     "doctrine/cache": "^1.8",
     "symfony/psr-http-message-bridge": "^1",


### PR DESCRIPTION
This PR plugs the [GraphQLite Symfony Validator bridge](https://github.com/thecodingmachine/graphqlite-symfony-validator-bridge/) into the Symfony bundle, making it available by default.