### PR TITLE
Configuring cache for Symfony 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
   include:
       # Test the latest stable release
     - php: 7.2
+      env: PHPSTAN=true
     - php: 7.3
       env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text"
 
@@ -51,7 +52,7 @@ script:
   # simple-phpunit is the PHPUnit wrapper provided by the PHPUnit Bridge component and
   # it helps with testing legacy code and deprecations (composer require symfony/phpunit-bridge)
   #- ./vendor/bin/simple-phpunit $PHPUNIT_FLAGS
-  - composer phpstan
+  - if [[ $PHPSTAN == true ]]; then composer phpstan; fi
   - ./vendor/bin/phpunit
 
 after_script:

--- a/DependencyInjection/GraphqliteCompilerPass.php
+++ b/DependencyInjection/GraphqliteCompilerPass.php
@@ -250,6 +250,13 @@ class GraphqliteCompilerPass implements CompilerPassInterface
         $this->mapAdderToTag('graphql.field_middleware', 'addFieldMiddleware', $container, $schemaFactory);
         $this->mapAdderToTag('graphql.type_mapper', 'addTypeMapper', $container, $schemaFactory);
         $this->mapAdderToTag('graphql.type_mapper_factory', 'addTypeMapperFactory', $container, $schemaFactory);
+
+        // Configure cache
+        if (ApcuAdapter::isSupported()) {
+            $container->setAlias('graphqlite.cache', 'graphqlite.apcucache');
+        } else {
+            $container->setAlias('graphqlite.cache', 'graphqlite.phpfilescache');
+        }
     }
 
     private function registerController(string $controllerClassName, ContainerBuilder $container): void

--- a/Resources/config/container/graphqlite.xml
+++ b/Resources/config/container/graphqlite.xml
@@ -13,7 +13,8 @@
         <defaults autowire="true" autoconfigure="true" public="false" />
 
         <service id="TheCodingMachine\GraphQLite\SchemaFactory">
-            <argument index="1" type="service" id="service_container" />
+            <argument type="service" id="graphqlite.psr16cache" />
+            <argument type="service" id="service_container" />
             <call method="setAuthenticationService">
                 <argument type="service" id="TheCodingMachine\GraphQLite\Security\AuthenticationServiceInterface" />
             </call>
@@ -101,6 +102,25 @@
                 <argument>TheCodingMachine\Graphqlite\Bundle\Types\SymfonyUserInterfaceType</argument>
             </argument>
             <tag name="graphql.type_mapper_factory"/>
+        </service>
+        
+        <service id="graphqlite.phpfilescache" class="Symfony\Component\Cache\Adapter\PhpFilesAdapter">
+            <argument>graphqlite</argument>
+        </service>
+
+        <service id="graphqlite.apcucache" class="Symfony\Component\Cache\Adapter\ApcuAdapter">
+            <argument>graphqlite</argument>
+        </service>
+
+        <service id="graphqlite.psr16cache" class="Symfony\Component\Cache\Psr16Cache">
+            <argument type="service" id="graphqlite.cache" />
+        </service>
+
+        <service id="graphqlite.cacheclearer" class="Symfony\Component\HttpKernel\CacheClearer\Psr6CacheClearer">
+            <argument type="collection">
+                <argument/>
+            </argument>
+            <tag name="kernel.cache_clearer"/>
         </service>
     </services>
 </container>

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "symfony/security-bundle": "^4.1.9 | ^5",
     "symfony/yaml": "^4.1.9 | ^5",
     "phpunit/phpunit": "^7.5.1",
-    "phpstan/phpstan": "^0.10.6",
+    "phpstan/phpstan-shim": "^0.11.19",
     "beberlei/porpaginas": "^1.2",
     "php-coveralls/php-coveralls": "^2.1.0"
   },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,9 +1,5 @@
 parameters:
     ignoreErrors:
         - "#Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeDefinition::children\\(\\)#"
-        # Error triggered by a bad PHPDoc in Symfony
-        - '#Parameter \#4 $roles of class Symfony\\Component\\Security\\Core\\Authentication\\Token\\UsernamePasswordToken constructor expects array<string>, array<string|Symfony\\Component\\Security\\Core\\Role\\Role> given.#'
-        - '#Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) invoked with 2 parameters, 1 required.#'
-        - '#Cannot cast object|string to string.#'
 #includes:
 #    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon


### PR DESCRIPTION
Symfony 5 does not provide a Simple cache instance by default.
This commit adds an already configured cache attached to GraphQLite (APCu with PHPFilesCache fallback)