### PR TITLE
Fixing loading of files with bad class names

### DIFF
--- a/Tests/Fixtures/Entities/BadClass.php
+++ b/Tests/Fixtures/Entities/BadClass.php
@@ -1,0 +1,8 @@
+<?php
+
+
+// The namespace for this class is broken. It must not impact Symfony.
+class BadClass
+{
+
+}

--- a/Tests/GraphqliteTestingKernel.php
+++ b/Tests/GraphqliteTestingKernel.php
@@ -63,6 +63,10 @@ class GraphqliteTestingKernel extends Kernel
                 'secret' => 'S0ME_SECRET'
             );
 
+            $frameworkConf['cache'] =[
+                'app' => 'cache.adapter.array',
+            ];
+
             if ($this->enableSession) {
                 $frameworkConf['session'] =[
                     'enabled' => true,
@@ -139,6 +143,6 @@ class GraphqliteTestingKernel extends Kernel
 
     public function getCacheDir()
     {
-        return __DIR__.'/../cache/'.spl_object_hash($this);
+        return __DIR__.'/../cache/'.($this->enableSession?'withSession':'withoutSession').$this->enableLogin.($this->enableSecurity?'withSecurity':'withoutSecurity').$this->enableMe;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "require" : {
     "php" : ">=7.2",
-    "thecodingmachine/graphqlite" : "~4.0.0",
+    "thecodingmachine/graphqlite" : "~4.0.1",
     "thecodingmachine/graphqlite-symfony-validator-bridge" : "~4.0.0",
     "symfony/framework-bundle": "^4.1.9 | ^5",
     "symfony/validator": "^4.1.9 | ^5",


### PR DESCRIPTION
Bypassing the autoloader to load classes.

Closes https://github.com/thecodingmachine/graphqlite/issues/216
See https://github.com/thecodingmachine/graphqlite/pull/217