### PR TITLE
Optimisation: checking only @Factory annotation in public methods

### DIFF
--- a/DependencyInjection/GraphqliteCompilerPass.php
+++ b/DependencyInjection/GraphqliteCompilerPass.php
@@ -194,7 +194,7 @@ class GraphqliteCompilerPass implements CompilerPassInterface
                     if ($typeAnnotation !== null || $this->getAnnotationReader()->getExtendTypeAnnotation($reflectionClass) !== null) {
                         $definition->setPublic(true);
                     }
-                    foreach ($reflectionClass->getMethods() as $method) {
+                    foreach ($reflectionClass->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
                         $factory = $reader->getFactoryAnnotation($method);
                         if ($factory !== null) {
                             $definition->setPublic(true);


### PR DESCRIPTION
This should speed up container building by only looking for @Factory annotation in public methods.