### PR TITLE
Migration to Laminas and PSR-HTTP bridge 2

### DIFF
--- a/Controller/GraphqliteController.php
+++ b/Controller/GraphqliteController.php
@@ -4,6 +4,11 @@
 namespace TheCodingMachine\Graphqlite\Bundle\Controller;
 
 
+use Laminas\Diactoros\ResponseFactory;
+use Laminas\Diactoros\ServerRequestFactory;
+use Laminas\Diactoros\StreamFactory;
+use Laminas\Diactoros\UploadedFileFactory;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use TheCodingMachine\GraphQLite\Http\HttpCodeDecider;
 use function array_map;
 use GraphQL\Error\ClientAware;
@@ -50,7 +55,7 @@ class GraphqliteController
     public function __construct(ServerConfig $serverConfig, HttpMessageFactoryInterface $httpMessageFactory = null, ?int $debug = Debug::RETHROW_UNSAFE_EXCEPTIONS)
     {
         $this->serverConfig = $serverConfig;
-        $this->httpMessageFactory = $httpMessageFactory ?: new DiactorosFactory();
+        $this->httpMessageFactory = $httpMessageFactory ?: new PsrHttpFactory(new ServerRequestFactory(), new StreamFactory(), new UploadedFileFactory(), new ResponseFactory());
         $this->debug = $debug ?? false;
     }
 

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,9 @@
     "symfony/translation": "^4.1.9 | ^5",
     "doctrine/annotations": "^1.6",
     "doctrine/cache": "^1.8",
-    "symfony/psr-http-message-bridge": "^1",
+    "symfony/psr-http-message-bridge": "^1.3",
     "nyholm/psr7": "^1.1",
-    "zendframework/zend-diactoros": "^1.8.6",
+    "laminas/laminas-diactoros": "^2.2.2",
     "overblog/graphiql-bundle": "^0.1.2 | ^0.2",
     "thecodingmachine/cache-utils": "^1"
   },


### PR DESCRIPTION
Zend Diactoros is deprecated in favor of Laminas.
This PR migrates Graphqlite bundle to use Laminas Diactoros as the default PSR-7 implementation.