### PR TITLE
Removing hidden dependency on the security-bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
   # it helps with testing legacy code and deprecations (composer require symfony/phpunit-bridge)
   #- ./vendor/bin/simple-phpunit $PHPUNIT_FLAGS
   - if [[ $PHPSTAN == true ]]; then composer phpstan; fi
-  - ./vendor/bin/phpunit
+  - ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
   # Let's test without the security bundle
   - if [[ $TESTNOSECURITYBUNDLE == true ]]; then composer remove --dev symfony/security-bundle && phpunit Tests/NoSecurityBundleTest.php; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,9 @@ script:
   #- ./vendor/bin/simple-phpunit $PHPUNIT_FLAGS
   - if [[ $PHPSTAN == true ]]; then composer phpstan; fi
   - ./vendor/bin/phpunit
+  # Let's test without the security bundle
+  - composer remove --dev symfony/security-bundle
+  - phpunit Tests/NoSecurityBundleTest.php
 
 after_script:
   - ./vendor/bin/php-coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - php: 7.2
       env: PHPSTAN=true
     - php: 7.4
-      env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text"
+      env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-text" TESTNOSECURITYBUNDLE=true
 
       # Test LTS versions.
     - php: 7.4
@@ -55,8 +55,7 @@ script:
   - if [[ $PHPSTAN == true ]]; then composer phpstan; fi
   - ./vendor/bin/phpunit
   # Let's test without the security bundle
-  - composer remove --dev symfony/security-bundle
-  - phpunit Tests/NoSecurityBundleTest.php
+  - if [[ $TESTNOSECURITYBUNDLE == true ]]; then composer remove --dev symfony/security-bundle && phpunit Tests/NoSecurityBundleTest.php; fi
 
 after_script:
   - ./vendor/bin/php-coveralls -v

--- a/Resources/config/container/graphqlite.xml
+++ b/Resources/config/container/graphqlite.xml
@@ -107,7 +107,6 @@
 
         <service id="TheCodingMachine\GraphQLite\Mappers\StaticClassListTypeMapperFactory">
             <argument type="collection">
-                <argument>TheCodingMachine\Graphqlite\Bundle\Types\SymfonyUserInterfaceType</argument>
             </argument>
             <tag name="graphql.type_mapper_factory"/>
         </service>

--- a/Tests/Fixtures/config/services.yaml
+++ b/Tests/Fixtures/config/services.yaml
@@ -17,6 +17,9 @@ services:
         resource: '../*'
         exclude: '../{Entities}'
 
+    TheCodingMachine\Graphqlite\Bundle\Tests\NoSecurityBundleFixtures\:
+        resource: '../../NoSecurityBundleFixtures/*'
+
     someService:
         class: stdClass
 

--- a/Tests/NoSecurityBundleFixtures/Controller/EchoController.php
+++ b/Tests/NoSecurityBundleFixtures/Controller/EchoController.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace TheCodingMachine\Graphqlite\Bundle\Tests\NoSecurityBundleFixtures\Controller;
+
+
+use TheCodingMachine\GraphQLite\Annotations\Query;
+
+class EchoController
+{
+    /**
+     * @Query()
+     */
+    public function echoMsg(string $message): string {
+        return $message;
+    }
+}

--- a/Tests/NoSecurityBundleTest.php
+++ b/Tests/NoSecurityBundleTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace TheCodingMachine\Graphqlite\Bundle\Tests;
+
+use function json_decode;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use function spl_object_hash;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\User;
+use TheCodingMachine\Graphqlite\Bundle\Controller\GraphqliteController;
+use TheCodingMachine\Graphqlite\Bundle\Security\AuthenticationService;
+use TheCodingMachine\GraphQLite\GraphQLRuntimeException as GraphQLException;
+use TheCodingMachine\GraphQLite\Schema;
+use function var_dump;
+
+/**
+ * This test class is supposed to work even if the security bundle is not installed in the project.
+ * It is here to check we don't have hidden dependencies on this bundle and that it remains optional.
+ */
+class NoSecurityBundleTest extends TestCase
+{
+    public function testServiceWiring(): void
+    {
+        $kernel = new GraphqliteTestingKernel(true, null, false, null, true, null, null, ['TheCodingMachine\\Graphqlite\\Bundle\\Tests\\NoSecurityBundleFixtures\\Controller\\']);
+        $kernel->boot();
+        $container = $kernel->getContainer();
+
+        $schema = $container->get(Schema::class);
+        $this->assertInstanceOf(Schema::class, $schema);
+        $schema->assertValid();
+
+        $request = Request::create('/graphql', 'GET', ['query' => '
+        { 
+          echoMsg(message: "Hello world")
+        }']);
+
+        $response = $kernel->handle($request);
+
+        $result = json_decode($response->getContent(), true);
+
+        $this->assertSame([
+            'data' => [
+                'echoMsg' => 'Hello world'
+            ]
+        ], $result);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,11 @@
   "require-dev": {
     "symfony/security-bundle": "^4.1.9 | ^5",
     "symfony/yaml": "^4.1.9 | ^5",
-    "phpunit/phpunit": "^7.5.1",
+    "phpunit/phpunit": "^8.5.5",
     "phpstan/phpstan": "^0.12.25",
     "beberlei/porpaginas": "^1.2",
     "php-coveralls/php-coveralls": "^2.1.0",
-    "symfony/phpunit-bridge": "^5.1"
+    "symfony/phpunit-bridge": "^4.1.9 | ^5.1"
   },
   "scripts": {
     "phpstan": "phpstan analyse GraphqliteBundle.php DependencyInjection/ Controller/ Resources/ Security/ -c phpstan.neon --level=7 --no-progress"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -35,6 +35,14 @@
     </logging>
 
     <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
+            <arguments>
+                <array>
+                    <!-- set this option to 0 to disable the DebugClassLoader integration -->
+                    <!-- See https://github.com/sebastianbergmann/phpunit/issues/4002 -->
+                    <element key="debug-class-loader"><integer>0</integer></element>
+                </array>
+            </arguments>
+        </listener>
     </listeners>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,7 +31,6 @@
 	</filter>
     <logging>
         <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
 
     <listeners>


### PR DESCRIPTION
The Graphqlite bundle would fail to load of the security-bundle was not in the project (because of a hidden dependency on Symfony's UserInterface)
This fixes the issue.

Closes #72