### PR TITLE
Fix getname on null

### DIFF
--- a/Mappers/RequestParameterMiddleware.php
+++ b/Mappers/RequestParameterMiddleware.php
@@ -18,7 +18,7 @@ class RequestParameterMiddleware implements ParameterMiddlewareInterface
 
     public function mapParameter(ReflectionParameter $parameter, DocBlock $docBlock, ?Type $paramTagType, ParameterAnnotations $parameterAnnotations, ParameterHandlerInterface $next): ParameterInterface
     {
-        if ($parameter->getType()->getName() === Request::class) {
+        if ($parameter->getType() and $parameter->getType()->getName() === Request::class) {
             return new RequestParameter();
         }
         return $next->mapParameter($parameter, $docBlock, $paramTagType, $parameterAnnotations);

--- a/Mappers/RequestParameterMiddleware.php
+++ b/Mappers/RequestParameterMiddleware.php
@@ -18,7 +18,8 @@ class RequestParameterMiddleware implements ParameterMiddlewareInterface
 
     public function mapParameter(ReflectionParameter $parameter, DocBlock $docBlock, ?Type $paramTagType, ParameterAnnotations $parameterAnnotations, ParameterHandlerInterface $next): ParameterInterface
     {
-        if ($parameter->getType() and $parameter->getType()->getName() === Request::class) {
+        $parameterType = $parameter->getType();
+        if ($parameterType && $parameterType->getName() === Request::class) {
             return new RequestParameter();
         }
         return $next->mapParameter($parameter, $docBlock, $paramTagType, $parameterAnnotations);


### PR DESCRIPTION
This PR fixes error: "Call to a member function getName() on null" 

I tried to use "Any" scalar type from here: https://github.com/thecodingmachine/graphqlite-misc-types.
Error appear when I use type-hint "scalar" in doc-block instead of php code.
