### PR TITLE
Command to dump schema

### DIFF
--- a/Command/DumpSchemaCommand.php
+++ b/Command/DumpSchemaCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TheCodingMachine\Graphqlite\Bundle\Command;
+
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Utils\SchemaPrinter;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TheCodingMachine\GraphQLite\Schema;
+
+/**
+ * Shamelessly stolen from Api Platform
+ */
+class DumpSchemaCommand extends Command
+{
+    protected static $defaultName = 'graphqlite:dump-schema';
+
+    /**
+     * @var Schema
+     */
+    private $schema;
+
+    public function __construct(Schema $schema)
+    {
+        $this->schema = $schema;
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Export the GraphQL schema in Schema Definition Language (SDL)')
+            ->addOption('output', 'o', InputOption::VALUE_REQUIRED, 'Write output to file');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        // Trying to guarantee deterministic order
+        $this->sortSchema();
+
+        $schemaExport = SchemaPrinter::doPrint($this->schema);
+
+        $filename = $input->getOption('output');
+        if (\is_string($filename)) {
+            file_put_contents($filename, $schemaExport);
+            $io->success(sprintf('Data written to %s.', $filename));
+        } else {
+            $output->writeln($schemaExport);
+        }
+
+        return 0;
+    }
+
+    private function sortSchema(): void
+    {
+        $config = $this->schema->getConfig();
+
+        $refl = new \ReflectionProperty(ObjectType::class, 'fields');
+        $refl->setAccessible(true);
+
+        $fields = $config->query->getFields();
+        ksort($fields);
+        $refl->setValue($config->query, $fields);
+
+        $fields = $config->mutation->getFields();
+        ksort($fields);
+        $refl->setValue($config->mutation, $fields);
+    }
+}

--- a/Command/DumpSchemaCommand.php
+++ b/Command/DumpSchemaCommand.php
@@ -39,7 +39,7 @@ class DumpSchemaCommand extends Command
             ->addOption('output', 'o', InputOption::VALUE_REQUIRED, 'Write output to file');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 

--- a/Resources/config/container/graphqlite.xml
+++ b/Resources/config/container/graphqlite.xml
@@ -129,5 +129,7 @@
             </argument>
             <tag name="kernel.cache_clearer"/>
         </service>
+
+        <service id="TheCodingMachine\Graphqlite\Bundle\Command\DumpSchemaCommand" />
     </services>
 </container>

--- a/Tests/TheCodingMachine/Graphqlite/Bundle/Tests/Command/DumpSchemaCommandTest.php
+++ b/Tests/TheCodingMachine/Graphqlite/Bundle/Tests/Command/DumpSchemaCommandTest.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace TheCodingMachine\Graphqlite\Bundle\Tests\Command;
+
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use TheCodingMachine\Graphqlite\Bundle\Tests\GraphqliteTestingKernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+class DumpSchemaCommandTest extends TestCase
+{
+    public function testExecute()
+    {
+        $kernel = new GraphqliteTestingKernel();
+        $application = new Application($kernel);
+
+        $command = $application->find('graphqlite:dump-schema');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([]);
+
+        $this->assertRegExp(
+            '/type Product {[\s"]*seller: Contact\s*name: String!\s*price: Float!\s*}/',
+            $commandTester->getDisplay()
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "nyholm/psr7": "^1.1",
     "laminas/laminas-diactoros": "^2.2.2",
     "overblog/graphiql-bundle": "^0.1.2 | ^0.2",
-    "thecodingmachine/cache-utils": "^1"
+    "thecodingmachine/cache-utils": "^1",
+    "symfony/console": "^4.1.9 | ^5"
   },
   "require-dev": {
     "symfony/security-bundle": "^4.2 || ^5",


### PR DESCRIPTION
Adding a command to dump schema for using with apollo codegen for example.
Sorting queries by name to have consistency and be able to rely on this in CI for example

This issue should be move to this repo
https://github.com/thecodingmachine/graphqlite/issues/352