### PR TITLE
cleanup boilerplate comment in GraphqliteCompilerPass

### DIFF
--- a/DependencyInjection/GraphqliteCompilerPass.php
+++ b/DependencyInjection/GraphqliteCompilerPass.php
@@ -323,7 +323,6 @@ class GraphqliteCompilerPass implements CompilerPassInterface
         $taggedServices = $container->findTaggedServiceIds($tag);
 
         foreach ($taggedServices as $id => $tags) {
-            // add the transport service to the TransportChain service
             $schemaFactory->addMethodCall($methodName, [new Reference($id)]);
         }
     }


### PR DESCRIPTION
stumbled upon a comment that seems to be copied from the tutorial but not relevant to the usage here https://symfony.com/doc/current/service_container/tags.html#create-a-compiler-pass