### PR TITLE
getContainerExtension() might add "?ExtensionInterface" as a native return type declaration

### DIFF
--- a/GraphQLiteBundle.php
+++ b/GraphQLiteBundle.php
@@ -20,7 +20,7 @@ class GraphQLiteBundle extends Bundle
         $container->addCompilerPass(new OverblogGraphiQLEndpointWiringPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -1);
     }
 
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         if (null === $this->extension) {
             $this->extension = new GraphQLiteExtension();


### PR DESCRIPTION
Avoid this error message
```
[info] User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::getContainerExtension()" might add "?ExtensionInterface" as a native return type declaration in the future. Do the same in child class "TheCodingMachine\GraphQLite\Bundle\GraphQLiteBundle" now to avoid errors or add an explicit @return annotation to suppress this message.
```
Valid from PHP 7.1 (this bundle required 7.2 and more).