### PR TITLE
Reuse more accurate check for APCu availability

### DIFF
--- a/DependencyInjection/GraphQLiteCompilerPass.php
+++ b/DependencyInjection/GraphQLiteCompilerPass.php
@@ -416,7 +416,7 @@ class GraphQLiteCompilerPass implements CompilerPassInterface
 
             $doctrineAnnotationReader = new DoctrineAnnotationReader();
 
-            if (function_exists('apcu_fetch')) {
+            if (ApcuAdapter::isSupported()) {
                 $doctrineAnnotationReader = new PsrCachedReader($doctrineAnnotationReader, new ApcuAdapter('graphqlite'), true);
             }
 
@@ -433,7 +433,7 @@ class GraphQLiteCompilerPass implements CompilerPassInterface
     private function getPsr16Cache(): CacheInterface
     {
         if ($this->cache === null) {
-            if (function_exists('apcu_fetch')) {
+            if (ApcuAdapter::isSupported()) {
                 $this->cache = new Psr16Cache(new ApcuAdapter('graphqlite_bundle'));
             } else {
                 $this->cache = new Psr16Cache(new PhpFilesAdapter('graphqlite_bundle', 0, $this->cacheDir));


### PR DESCRIPTION
It is already used in the same class, so this change makes checks more consistent: https://github.com/thecodingmachine/graphqlite-bundle/blob/b7682aa13ccec13f8eb0073b8ed89f7a757d831f/DependencyInjection/GraphQLiteCompilerPass.php#L287