### PR TITLE
Add symfony cache dir to graphqlite file adapter service

### DIFF
--- a/Resources/config/container/graphqlite.xml
+++ b/Resources/config/container/graphqlite.xml
@@ -115,6 +115,8 @@
 
         <service id="graphqlite.phpfilescache" class="Symfony\Component\Cache\Adapter\PhpFilesAdapter">
             <argument>graphqlite</argument>
+            <argument>0</argument>
+            <argument>%kernel.cache_dir%</argument>
         </service>
 
         <service id="graphqlite.apcucache" class="Symfony\Component\Cache\Adapter\ApcuAdapter">


### PR DESCRIPTION
Hello,

By investigating some permissions issues on graphqlite cache files, I've noticed that `graphqlite-bundle` cache files are properly set in Symfony cache folder since [this PR](https://github.com/thecodingmachine/graphqlite-bundle/pull/79), but `graphqlite` cache files are still in `tmp` folder because of the service configuration :
https://github.com/thecodingmachine/graphqlite-bundle/blob/54959bd615fd848abaf476cbaae6a56d300df232/Resources/config/container/graphqlite.xml#L116-L118

As no value is provided for the directory argument of the adapter, [the tmp directory is used](https://github.com/symfony/symfony/blob/9b2a4db4c6de0926729c305821712b3a64c1df3c/src/Symfony/Component/Cache/Traits/FilesystemCommonTrait.php#L28-L29) (with a `symfony-cache` folder created inside).

So this PR is to apply the same change (kind of) of the previous PR but for the `graphqlite` related cache service.