### PR TITLE
[Error handling] Remove category from exceptions

### DIFF
--- a/Controller/GraphQL/InvalidUserPasswordException.php
+++ b/Controller/GraphQL/InvalidUserPasswordException.php
@@ -10,6 +10,6 @@ class InvalidUserPasswordException extends GraphQLException
 {
     public static function create(Exception $previous = null): self
     {
-        return new self('The provided user / password is incorrect.', 401, $previous, 'Security');
+        return new self('The provided user / password is incorrect.', 401, $previous);
     }
 }

--- a/Tests/Fixtures/Controller/TestGraphqlController.php
+++ b/Tests/Fixtures/Controller/TestGraphqlController.php
@@ -81,7 +81,7 @@ class TestGraphqlController
     public function triggerAggregateException(): string
     {
         $exception1 = new GraphQLException('foo', 401);
-        $exception2 = new GraphQLException('bar', 404, null, 'MyCat', ['field' => 'baz', 'category' => 'MyCat']);
+        $exception2 = new GraphQLException('bar', 404, null, ['field' => 'baz']);
         throw new GraphQLAggregateException([$exception1, $exception2]);
     }
 

--- a/Tests/FunctionalTest.php
+++ b/Tests/FunctionalTest.php
@@ -153,7 +153,6 @@ class FunctionalTest extends TestCase
 
         $this->assertSame('foo', $result['errors'][0]['message']);
         $this->assertSame('bar', $result['errors'][1]['message']);
-        $this->assertSame('MyCat', $result['errors'][1]['extensions']['category']);
         $this->assertSame('baz', $result['errors'][1]['extensions']['field']);
     }
 
@@ -463,7 +462,6 @@ class FunctionalTest extends TestCase
 
         $this->assertSame('This value is not a valid email address.', $errors[0]['message']);
         $this->assertSame('email', $errors[0]['extensions']['field']);
-        $this->assertSame('Validate', $errors[0]['extensions']['category']);
     }
 
     public function testWithIntrospection(): void


### PR DESCRIPTION
Apply changes from https://github.com/thecodingmachine/graphqlite/pull/685 to the bundle.

> [!WARNING]
> Do no not merge until merge and release of https://github.com/thecodingmachine/graphqlite/pull/685

> [!NOTE]
> Still having error running test about `DependencyInjection/Configuration.php` not compatible with implemented interface. Not fixed it in this PR (as already done in #208), but should probably split it into a distinct PR.