### PR TITLE
Orders type fields in the dump schema command using the sortFields flag.

### DIFF
--- a/Command/DumpSchemaCommand.php
+++ b/Command/DumpSchemaCommand.php
@@ -43,7 +43,7 @@ class DumpSchemaCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $schemaExport = SchemaPrinterForGraphQLite::doPrint($this->schema, ['sortTypes' => true]);
+        $schemaExport = SchemaPrinterForGraphQLite::doPrint($this->schema, ['sortTypes' => true, 'sortFields' => true]);
 
         $filename = $input->getOption('output');
         if (\is_string($filename)) {

--- a/Tests/Command/DumpSchemaCommandTest.php
+++ b/Tests/Command/DumpSchemaCommandTest.php
@@ -19,7 +19,7 @@ class DumpSchemaCommandTest extends TestCase
         $commandTester->execute([]);
 
         self::assertMatchesRegularExpression(
-            '/type Product {[\s"]*seller: Contact\s*name: String!\s*price: Float!\s*}/',
+            '/type Product {[\s"]*name: String!\s*price: Float!\s*seller: Contact\s*}/',
             $commandTester->getDisplay()
         );
     }


### PR DESCRIPTION
Currently, the Mutation and Query types are not always ordered consistently, which makes the schema generated by the command unpredictable. This might be due to the change made [here](https://github.com/thecodingmachine/graphqlite-bundle/commit/5ffa1d79e02820551706959150f9c4189fc4c7fd).

With this PR, I am introducing the sorting of fields within the types included in the generated schema, using the supported `sortFields` flag. This way, all fields will always be ordered alphabetically, and the generated schema will be predictable, making it easier, for instance, to verify that the schema generated at runtime matches the expected one.