### PR TITLE
Actualize badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 [![Latest Stable Version](https://poser.pugx.org/thecodingmachine/graphqlite-bundle/v/stable)](https://packagist.org/packages/thecodingmachine/graphqlite-bundle)
-[![Latest Unstable Version](https://poser.pugx.org/thecodingmachine/graphqlite-bundle/v/unstable)](https://packagist.org/packages/thecodingmachine/graphqlite-bundle)
 [![License](https://poser.pugx.org/thecodingmachine/graphqlite-bundle/license)](https://packagist.org/packages/thecodingmachine/graphqlite-bundle)
-[![Build Status](https://travis-ci.org/thecodingmachine/graphqlite-bundle.svg?branch=master)](https://travis-ci.org/thecodingmachine/graphqlite-bundle)
-
+[![Build Status](https://github.com/thecodingmachine/graphqlite-bundle/actions/workflows/test.yaml/badge.svg)](https://github.com/thecodingmachine/graphqlite-bundle/actions/workflows/test.yaml/badge.svg)
 
 # GraphQLite bundle
 
-Symfony 5 bundle for the thecodingmachine/graphqlite package.
+Symfony bundle for the `thecodingmachine/graphqlite` package.
 
-See [thecodingmachine/graphqlite](https://github.com/thecodingmachine/graphqlite)
+See [thecodingmachine/graphqlite](https://github.com/thecodingmachine/graphqlite).


### PR DESCRIPTION
- We're not using release dev branches here - a badge about an unstable version is not necessary
- Changed Travis CI build status to GitHub Actions
- Dropped mention for Symfony version