### PR TITLE
[CI] Set zend.assertions to 1 ini PHP Setup to break on asserts

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,6 +28,7 @@ jobs:
               uses: shivammathur/setup-php@2.30.4
               with:
                   php-version: ${{ matrix.php-version }}
+                  ini-values: zend.assertions=1
 
             - name: composer-cache-dir
               id: composercache


### PR DESCRIPTION
Hi,

As mentioned in https://github.com/thecodingmachine/graphqlite-bundle/pull/249, currently the CI tests doesn't break on PHP `assert` because `zend.assertions` is not set by default to `1` on the config currently used by setup-php action.

Cf. https://github.com/shivammathur/setup-php/issues/582

Tests on this PR should break so because of assert on security config node, fixed by https://github.com/thecodingmachine/graphqlite-bundle/pull/249.

> [!NOTE]
> I've only set the `zend.assertions` config here, but it might be better to use `ini-file: development` instead which use a PHP ini config file for development. But maybe it will break more with it so we should try it later. 