### PR TITLE
:package: Avoid failed assert in case of not specified namespace config

### DIFF
--- a/src/DependencyInjection/GraphQLiteExtension.php
+++ b/src/DependencyInjection/GraphQLiteExtension.php
@@ -36,6 +36,9 @@ class GraphQLiteExtension extends Extension
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config/container'));
 
+        if (!isset($config['namespace'])) {
+            $config['namespace'] = [];
+        }
         \assert(\is_array($config['namespace']));
         if (isset($config['namespace']['controllers'])) {
             $controllers = $config['namespace']['controllers'];


### PR DESCRIPTION
An application can register graphql types on its own via compiler passes

Follows https://github.com/thecodingmachine/graphqlite-bundle/pull/249