### PR TITLE
Port 6.x changes (graphql upload support and composer suggestion)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
     "phpstan": "phpstan analyse -c phpstan.neon --no-progress"
   },
   "suggest": {
+    "ecodev/graphql-upload": "If you want to support file upload inside GraphQL input types (v7/v8)",
     "symfony/security-bundle": "To use #[Logged] or #[Right] attributes"
   },
   "autoload" : {

--- a/src/UploadMiddlewareUtils/DummyResponseWithRequest.php
+++ b/src/UploadMiddlewareUtils/DummyResponseWithRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Bundle\UploadMiddlewareUtils;
+
+use Laminas\Diactoros\Response;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Class used to allow extraction of request from PSR-15 middleware
+ *
+ * @internal
+ */
+class DummyResponseWithRequest extends Response
+{
+    private ServerRequestInterface $request;
+
+    public function __construct(ServerRequestInterface $request)
+    {
+        parent::__construct();
+        $this->request = $request;
+    }
+
+    public function getRequest(): ServerRequestInterface
+    {
+        return $this->request;
+    }
+}

--- a/src/UploadMiddlewareUtils/RequestExtractorMiddleware.php
+++ b/src/UploadMiddlewareUtils/RequestExtractorMiddleware.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace TheCodingMachine\GraphQLite\Bundle\UploadMiddlewareUtils;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Middleware to extract the request from the middleware chain
+ *
+ * @internal
+ */
+class RequestExtractorMiddleware implements RequestHandlerInterface
+{
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        return new DummyResponseWithRequest($request);
+    }
+
+}


### PR DESCRIPTION
This merges the following commits:
- [👽 Support ecodev/graphql-upload v8](https://github.com/thecodingmachine/graphqlite-bundle/commit/128ac9cdc01748bef7c3922d720101ca7564161c)
- [📦 Suggest installing ecodev/graphql-upload (v7/v8)](https://github.com/thecodingmachine/graphqlite-bundle/commit/119353e2ebe293290b1f483f692ec51b79d76384)
- [📦 Fix middleware utils placement to be consistent with other files](https://github.com/thecodingmachine/graphqlite-bundle/commit/d12fda4a8c596b378d70a0843d760ab8d89571ff)
- [📦 Resolve phpstan issue - PHP 8.4 deprecation](https://github.com/thecodingmachine/graphqlite-bundle/commit/857d35a05d9ba7cf22a7b72e3c56d51849f94d23)
- [📦 Bump actions/cache to v5 to avoid failed CI with deprecated cache version](https://github.com/thecodingmachine/graphqlite-bundle/commit/a227d09099c1eaec42dfdce2d9bfab48bad7d0e7)

In the merge commit (conflicts) I moved the `UploadMiddlewareUtils/` directory to `src/` and I used `get_debug_type` instead of `get_class`